### PR TITLE
Postgresql dump loading fix

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- Postgresql search path issue
+
 `0.3.0`_ - 2018-03-13
 ---------------------
 

--- a/xdump/postgresql.py
+++ b/xdump/postgresql.py
@@ -132,6 +132,17 @@ class PostgreSQLBackend(BaseBackend):
             self.copy_expert('COPY ({0}) TO STDOUT WITH CSV HEADER'.format(sql), output)
             return output.getvalue()
 
+    def get_search_path(self):
+        return self.run('show search_path;')[0]['search_path']
+
+    def restore_search_path(self, search_path):
+        self.run("SELECT pg_catalog.set_config('search_path', '{0}', false);".format(search_path))
+
+    def initial_setup(self, archive):
+        search_path = self.get_search_path()
+        super().initial_setup(archive)
+        self.restore_search_path(search_path)
+
     def recreate_database(self, owner=None):
         self.drop_connections(self.dbname)
         super().recreate_database(owner)


### PR DESCRIPTION
Since this update https://www.postgresql.org/about/news/1834/ dump loading isn't working, because schema.sql now contains 
`SELECT pg_catalog.set_config('search_path', '', false);`
