### PR TITLE
fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.rst") as file:
     long_description = file.read()
 
 install_requires = [
-    "attrs",
+    "attrs>=19.2.0",
     "psycopg2",
     "click>=6",
 ]

--- a/xdump/__init__.py
+++ b/xdump/__init__.py
@@ -1,4 +1,4 @@
 # coding: utf-8
 
 
-__version__ = "0.7.0"
+__version__ = "0.6.0"

--- a/xdump/__init__.py
+++ b/xdump/__init__.py
@@ -1,4 +1,4 @@
 # coding: utf-8
 
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/xdump/postgresql.py
+++ b/xdump/postgresql.py
@@ -68,8 +68,8 @@ class PostgreSQLBackend(BaseBackend):
     user = attr.ib()
     password = attr.ib()
     host = attr.ib()
-    port = attr.ib(convert=str)
-    verbosity = attr.ib(convert=int, default=0)
+    port = attr.ib(converter=str)
+    verbosity = attr.ib(converter=int, default=0)
     sequences_filename = "dump/sequences.sql"
     initial_setup_files = BaseBackend.initial_setup_files + (sequences_filename,)
     connections = {

--- a/xdump/sqlite.py
+++ b/xdump/sqlite.py
@@ -27,7 +27,7 @@ TABLES_SQL = "SELECT name AS table_name FROM sqlite_master WHERE type='table'"
 @attr.s(cmp=False)
 class SQLiteBackend(BaseBackend):
     dbname = attr.ib()
-    verbosity = attr.ib(convert=int, default=0)
+    verbosity = attr.ib(converter=int, default=0)
 
     def __attrs_post_init__(self):
         if sqlite3.sqlite_version_info < (3, 8, 3):


### PR DESCRIPTION
from attrs there are backward-incompatible Changes:

Removed deprecated Attribute attribute **convert** per scheduled removal on 2019/1. This planned deprecation is tracked in issue [#307](https://github.com/python-attrs/attrs/issues/307). [#504](https://github.com/python-attrs/attrs/issues/504)

